### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ Decompress.prototype._extractZip = function () {
         zip.getEntries().forEach(function (entry) {
             if (!entry.isDirectory) {
                 var dest;
-                var dir = path.dirname(entry.entryName.toString()).split(path.sep);
+                var dir = path.dirname(entry.entryName.toString()).split('/');
                 var file = path.basename(entry.rawEntryName.toString());
 
                 if (self.strip) {


### PR DESCRIPTION
According to the ZIP specification (http://www.pkware.com/documents/casestudies/APPNOTE.TXT) the path separators are always forward slashes '/' (see 4.4.17) and thus may not match the path.sep value. On Windows systems this results in unsuccessful strip execution.

This fixes issue https://github.com/kevva/decompress/issues/14.
