### PR TITLE
Use graceful-fs to prevent EMFILE issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
-const fs = require('graceful-fs');
 const path = require('path');
+const fs = require('graceful-fs');
 const decompressTar = require('decompress-tar');
 const decompressTarbz2 = require('decompress-tarbz2');
 const decompressTargz = require('decompress-targz');

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const fs = require('fs');
+const fs = require('graceful-fs');
 const path = require('path');
 const decompressTar = require('decompress-tar');
 const decompressTarbz2 = require('decompress-tarbz2');

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "decompress-tarbz2": "^4.0.0",
     "decompress-targz": "^4.0.0",
     "decompress-unzip": "^4.0.1",
+    "graceful-fs": "^4.1.10",
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",
     "strip-dirs": "^2.0.0"


### PR DESCRIPTION
I'm using this for a Go command wrapper which download's and unpack's the latest Go release, and finding that in Windows EMFILE errors are common when unpacking via decompress.

Using [graceful-fs](https://github.com/isaacs/node-graceful-fs) takes care of that.