### PR TITLE
update returned file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ const extractFile = (input, output, opts) => runPlugins(input, opts).then(files 
 		const dest = path.join(output, x.path);
 		const mode = x.mode & ~process.umask();
 		const now = new Date();
+		x.path = dest;
 
 		if (x.type === 'directory') {
 			return pify(mkdirp)(dest)


### PR DESCRIPTION
Update each file's 'path' attribute with the output folder, so that if the returned files are used down the pipe (like in gulp-decompress) they have the correct final path