### PR TITLE
No symlinks

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,15 +54,19 @@ const extractFile = (input, output, opts) => runPlugins(input, opts).then(files 
 
 		return makeDir(path.dirname(dest))
 			.then(() => {
-				if (x.type === 'link' && opts.symlinks !== false) {
+				if ((x.type === 'link' || x.type === 'symlink') && opts.symlinks === false) {
+					return;
+				}
+
+				if (x.type === 'link') {
 					return fsP.link(x.linkname, dest);
 				}
 
-				if (x.type === 'symlink' && process.platform === 'win32' && opts.symlinks !== false) {
+				if (x.type === 'symlink' && process.platform === 'win32') {
 					return fsP.link(x.linkname, dest);
 				}
 
-				if (x.type === 'symlink' && opts.symlinks !== false) {
+				if (x.type === 'symlink') {
 					return fsP.symlink(x.linkname, dest);
 				}
 

--- a/index.js
+++ b/index.js
@@ -54,15 +54,15 @@ const extractFile = (input, output, opts) => runPlugins(input, opts).then(files 
 
 		return makeDir(path.dirname(dest))
 			.then(() => {
-				if (x.type === 'link') {
+				if (x.type === 'link' && opts.symlinks !== false) {
 					return fsP.link(x.linkname, dest);
 				}
 
-				if (x.type === 'symlink' && process.platform === 'win32') {
+				if (x.type === 'symlink' && process.platform === 'win32' && opts.symlinks !== false) {
 					return fsP.link(x.linkname, dest);
 				}
 
-				if (x.type === 'symlink') {
+				if (x.type === 'symlink' && opts.symlinks !== false) {
 					return fsP.symlink(x.linkname, dest);
 				}
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "github.com/kevva"
 	},
 	"engines": {
-		"node": ">=4"
+		"node": ">=7.6.0"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -41,9 +41,20 @@
 	},
 	"devDependencies": {
 		"ava": "*",
+		"esm": "^3.2.25",
 		"is-jpg": "^1.0.0",
 		"path-exists": "^3.0.0",
 		"pify": "^2.3.0",
 		"xo": "*"
+	},
+	"ava": {
+		"require": [
+			"esm"
+		]
+	},
+	"xo": {
+		"rules": {
+			"promise/prefer-await-to-then": "off"
+		}
 	}
 }

--- a/test.js
+++ b/test.js
@@ -50,7 +50,14 @@ test.serial('extract file to directory', async t => {
 	await fsP.unlink(path.join(__dirname, 'test.jpg'));
 });
 
-test('extract symlink', async t => {
+test.serial('extract without symlink', async t => {
+	await m(path.join(__dirname, 'fixtures', 'symlink.tar'), __dirname, {strip: 1, symlinks: false});
+	t.not(await fsP.realpath(path.join(__dirname, 'symlink')), path.join(__dirname, 'file.txt'));
+	await fsP.unlink(path.join(__dirname, 'symlink'));
+	await fsP.unlink(path.join(__dirname, 'file.txt'));
+});
+
+test.serial('extract symlink', async t => {
 	await m(path.join(__dirname, 'fixtures', 'symlink.tar'), __dirname, {strip: 1});
 	t.is(await fsP.realpath(path.join(__dirname, 'symlink')), path.join(__dirname, 'file.txt'));
 	await fsP.unlink(path.join(__dirname, 'symlink'));
@@ -99,7 +106,7 @@ test.serial('set mtime', async t => {
 	await fsP.unlink(path.join(__dirname, 'test.jpg'));
 });
 
-test('return emptpy array if no plugins are set', async t => {
+test('return empty array if no plugins are set', async t => {
 	const files = await m(path.join(__dirname, 'fixtures', 'file.tar'), {plugins: []});
 	t.is(files.length, 0);
 });

--- a/test.js
+++ b/test.js
@@ -52,8 +52,7 @@ test.serial('extract file to directory', async t => {
 
 test.serial('extract without symlink', async t => {
 	await m(path.join(__dirname, 'fixtures', 'symlink.tar'), __dirname, {strip: 1, symlinks: false});
-	t.not(await fsP.realpath(path.join(__dirname, 'symlink')), path.join(__dirname, 'file.txt'));
-	await fsP.unlink(path.join(__dirname, 'symlink'));
+	t.false(fs.existsSync(path.join(__dirname, 'symlink')));
 	await fsP.unlink(path.join(__dirname, 'file.txt'));
 });
 


### PR DESCRIPTION
This addresses #71 by creating a new option `symlinks` which defaults `true`. If `false` then symlinks will not be created at all. This does not match the behavior of `unzip` or `tar` which would create the symlink but fail when creating a file outside of the extraction directory with a `checkdir` error:

```
$ unzip slip.zip 
Archive:  slip.zip
    linking: symlink_to_root         -> / 
    linking: generic_dir/symlink_to_parent_dir  -> ../ 
checkdir error:  generic_dir/symlink_to_parent_dir exists but is not directory
                 unable to process generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/symlink_to_root/tmp/slipped_zip.txt.
finishing deferred symbolic links:
  symlink_to_root        -> /
  generic_dir/symlink_to_parent_dir -> ../
```

In this pull request, the symlink is never written at all:

Running: 

```
decompress('slip.zip', 'dist', {symlinks: false}).then(files => {
	console.log('done!');
});
```

Will not error out but will not create any of the links or `/tmp/slipped_zip.txt` (though it will create a normal file `generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/generic_dir/symlink_to_parent_dir/symlink_to_root/tmp/slipped_zip.txt` in the destination folder `dist`).

This cherry-picks the test fixes from @trptcolin

This fix should be entirely backward compatible but can be leveraged by bin-build and others to ensure that they are not vulnerable in a new version which disables symlinks.

Paired with @goodgravy